### PR TITLE
Fix the search css bug on page reload

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -9,12 +9,12 @@
   <audio id="media"></audio>
   <div id="overlay">
     <div class="allowDrop" style="
-                                                    color: var(--succeed);
-                                                    place-items: center;
-                                                    font-size: 20px;
-                                                    font-weight: bold;
-                                                    padding: 10px;
-                                                  ">
+                                                      color: var(--succeed);
+                                                      place-items: center;
+                                                      font-size: 20px;
+                                                      font-weight: bold;
+                                                      padding: 10px;
+                                                    ">
       <svg id="svg1" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none"
         stroke="#66ff66" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -24,12 +24,12 @@
       <div>Import</div>
     </div>
     <div class="deniDrop" style="
-                                                    color: var(--fail);
-                                                    place-items: center;
-                                                    font-size: 20px;
-                                                    font-weight: bold;
-                                                    padding: 10px;
-                                                  ">
+                                                      color: var(--fail);
+                                                      place-items: center;
+                                                      font-size: 20px;
+                                                      font-weight: bold;
+                                                      padding: 10px;
+                                                    ">
       <svg id="svg2" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none"
         stroke="#ff6666" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <line x1="18" y1="6" x2="6" y2="18"></line>

--- a/components/player.vue
+++ b/components/player.vue
@@ -51,7 +51,7 @@ function chageNowPlaying(img, name, artist) {
     artwork: [{ src: img }]
   })
 
-  navigator.mediaSession.setActionHandler("nexttrack", chageNowPlaying);
+  navigator.mediaSession.setActionHandler("nexttrack", chageNowPlaying); // should change changeNowPlaying to actual (next) function when available
   navigator.mediaSession.setActionHandler("previoustrack", back);
 }
 

--- a/css/search.css
+++ b/css/search.css
@@ -6,7 +6,22 @@
 }
 
 .search {
-  margin-bottom: 0;
+  position: fixed;
+  top: 40px;
+  width: 325px;
+  height: 40px;
+  background-color: #1e1d23;
+  border: 1px solid #26252b;
+  border-radius: 10px;
+  font-family: "Inter", sans-serif;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  padding-inline: 10px;
+  color: var(--tx);
+  outline: none;
+  margin-bottom: 28px;
+  z-index: 3;
 }
 
 .searchResults {
@@ -65,7 +80,6 @@
   font-size: 12px;
 }
 
-
 .bigResult {
   display: flex;
   height: 188px;
@@ -80,7 +94,6 @@
   height: 188px !important;
   width: 424px !important;
 }
-
 
 .flip.searchResults {
   scale: 1 -1;
@@ -122,7 +135,11 @@
   --gradientColor1: #404050;
   --gradientColor2: #413350;
   background: unset;
-  background-image: linear-gradient(180deg, var(--gradientColor1) 0%, var(--gradientColor2) 100%) !important;
+  background-image: linear-gradient(
+    180deg,
+    var(--gradientColor1) 0%,
+    var(--gradientColor2) 100%
+  ) !important;
 }
 
 .float.searchResults {
@@ -151,7 +168,6 @@
   background-color: transparent;
 }
 
-
 .resize.bigResult {
   resize: both;
 }
@@ -167,7 +183,7 @@
   align-self: end;
 }
 
-.bigResult .searchResultPlay>img {
+.bigResult .searchResultPlay > img {
   width: 25px;
 }
 
@@ -204,7 +220,7 @@
 }
 
 .gotoTop {
-  transition: .5s;
+  transition: 0.5s;
   position: fixed;
   width: 30px;
   height: 30px;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { defineNuxtConfig } from 'nuxt/config'
+import { defineNuxtConfig } from "nuxt/config";
 
 export default defineNuxtConfig({
-  ssr: false
-})
+  modules: ["@nuxt/devtools"],
+  devtools: {
+    enabled: true,
+  },
+  ssr: false,
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "nuxt prepare"
   },
   "devDependencies": {
+    "@nuxt/devtools": "^0.5.5",
     "@tauri-apps/cli": "^1.2.3",
     "nuxt": "^3.5.1"
   },


### PR DESCRIPTION
Regarding issue #2 
When page reloads, it only loads the css imported at page: search.vue and doesnt load the actual css of the component: search.vue 

Fix: Copy the styles on search.vue component into the search.css imported at search.vue page

```css
.search {
  position: fixed;
  top: 40px;
  width: 325px;
  height: 40px;
  background-color: #1e1d23;
  border: 1px solid #26252b;
  border-radius: 10px;
  font-family: "Inter", sans-serif;
  font-size: 16px;
  display: flex;
  align-items: center;
  padding-inline: 10px;
  color: var(--tx);
  outline: none;
  margin-bottom: 28px;
  z-index: 3;
}
``` 